### PR TITLE
Move about button + Project URI support

### DIFF
--- a/js/components.js
+++ b/js/components.js
@@ -6,9 +6,9 @@ Vue.component("navbar", {
 			<img src="img/icon.svg">
 			Project Explorer
 		</span>
+		<span class="header-item about button"><img src="img/info.svg" v-on:click="$parent.showAboutScreen" alt="About"></span>
 		<span class="header-item projtitle header-input">{{$parent.projTitle}}</span>
 		<input id="projIDInput" v-model="$parent.idInputVal" v-on:change="$parent.loadProject($parent.idInputVal)" class="header-item projid header-input" placeholder="Enter a project ID...">
-		<span class="header-item about button"><img src="img/info.svg" v-on:click="$parent.showAboutScreen" alt="About"></span>
 	</div>
 </div>`
 });

--- a/js/methods.js
+++ b/js/methods.js
@@ -5,16 +5,17 @@ let methods = {};
 methods.loadProject = async function(id) {
 	
 	this.projTitle = "Project";
-	
+	var idnum;
 	//In case we already have a project loaded
 	this.projectReady = false;
 	
 	//If the ID is not a number, it is instantly not a valid project
-	if (isNaN(id) || id === "") {
+	if ((isNaN(id) && id.includes("scratch.mit.edu/projects/")) || id === "") {
 		this.projectMessage = "Project ID is not a number. Make sure to use the project ID, not the URL.";
 		return;
+	} else {
+		idnum = id.replace("https://", "").replace("http://", "").replace("scratch.mit.edu/projects/", "").replace("/", "")
 	}
-	
 	
 	function doProjectName() {
 		//Fetch project name from ScratchDB


### PR DESCRIPTION
now converts scratch project urls to a number, and i moved the about icon right next to the logo, because it’s weird to put it next to a project control.